### PR TITLE
feat: change the option format

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,18 @@ $ trivy plugin install github.com/aquasecurity/trivy-plugin-attest
 ## Usage
 
 ```
-Usage: trivy attest [-h,--help] PREDICATE_TYPE PREDICATE_PATH BLOB_PATH
- A Trivy plugin that publish SBOM attestation.
+A Trivy plugin that publish SBOM attestation
+
+Usage:
+  attest [flags]
+
 Examples:
+  trivy attest --type PREDICATE_TYPE --predicate PREDICATE_PATH BLOB_PATH
   # Publish SBOM attestation
-  trivy attest cyclonedx ./sbom.cdx.json ./my-executable
+  trivy attest --type cyclonedx --predicate ./sbom.cdx.json ./my-executable
+
+Flags:
+  -h, --help               help for attest
+      --predicate string   specify the predicate file path
+      --type string        specify the predicate type(cyclonedx)
 ```

--- a/go.mod
+++ b/go.mod
@@ -124,7 +124,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/jedisct1/go-minisign v0.0.0-20211028175153-1c139d1cc84b // indirect
 	github.com/jhump/protoreflect v1.13.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
@@ -170,7 +170,7 @@ require (
 	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
-	github.com/spf13/cobra v1.5.0 // indirect
+	github.com/spf13/cobra v1.6.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -917,6 +917,8 @@ github.com/in-toto/in-toto-golang v0.4.0 h1:9iUcYy6d1nk8TjMzhTmEvO8sMp+oBnbgEq72
 github.com/in-toto/in-toto-golang v0.4.0/go.mod h1:KqmIkX/ZhX3rqGW6TzQK9YGTMHWTFaD3y82u6mxVrfs=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
+github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/jarcoal/httpmock v1.0.5/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
@@ -1393,6 +1395,8 @@ github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t6
 github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
 github.com/spf13/cobra v1.5.0 h1:X+jTBEBqF0bHN+9cSMgmfuvv2VHJ9ezmFNf9Y/XstYU=
 github.com/spf13/cobra v1.5.0/go.mod h1:dWXEIy2H428czQCjInthrTRUg7yKbok+2Qi/yBIJoUM=
+github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
+github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 name: "attest"
 repository: github.com/aquasecurity/trivy-plugin-attest
-version: "0.0.1"
+version: "0.1.0"
 usage: publish SBOM attestation
 description: |-
   A Trivy plugin that publish SBOM attestation
@@ -9,20 +9,20 @@ platforms:
   - selector:
       os: darwin
       arch: amd64
-    uri: https://github.com/aquasecurity/trivy-plugin-attest/releases/download/v0.0.1/trivy_plugin_attest_0.0.1_macOS-64bit.tar.gz
+    uri: https://github.com/aquasecurity/trivy-plugin-attest/releases/download/v0.1.0/trivy_plugin_attest_0.1.0_macOS-64bit.tar.gz
     bin: ./attest
   - selector:
       os: darwin
       arch: arm64
-    uri: https://github.com/aquasecurity/trivy-plugin-attest/releases/download/v0.0.1/trivy_plugin_attest_0.0.1_macOS-ARM64.tar.gz
+    uri: https://github.com/aquasecurity/trivy-plugin-attest/releases/download/v0.1.0/trivy_plugin_attest_0.1.0_macOS-ARM64.tar.gz
     bin: ./attest
   - selector:
       os: linux
       arch: amd64
-    uri: https://github.com/aquasecurity/trivy-plugin-attest/releases/download/v0.0.1/trivy_plugin_attest_0.0.1_Linux-64bit.tar.gz
+    uri: https://github.com/aquasecurity/trivy-plugin-attest/releases/download/v0.1.0/trivy_plugin_attest_0.1.0_Linux-64bit.tar.gz
     bin: ./attest
   - selector:
       os: linux
       arch: arm64
-    uri: https://github.com/aquasecurity/trivy-plugin-attest/releases/download/v0.0.1/trivy_plugin_attest_0.0.1_Linux-ARM64.tar.gz
+    uri: https://github.com/aquasecurity/trivy-plugin-attest/releases/download/v0.1.0/trivy_plugin_attest_0.1.0_Linux-ARM64.tar.gz
     bin: ./attest

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -4,7 +4,7 @@ version: "0.1.0"
 usage: publish SBOM attestation
 description: |-
   A Trivy plugin that publish SBOM attestation
-  Usage: trivy attest PREDICATE_TYPE PREDICATE_PATH BLOB_PATH
+  Usage: trivy attest --type PREDICATE_TYPE --predicate PREDICATE_PATH BLOB_PATH
 platforms:
   - selector:
       os: darwin


### PR DESCRIPTION
## Description

I have changed the format of the option to be like a cosign.

**before**
```
$  trivy attest cyclonedx ./sbom.cdx.json ./my-executable
```

**after**
```
$  trivy attest --type cyclonedx --predicate ./sbom.cdx.json ./my-executable
```

```
> ./trivy attest -h
A Trivy plugin that publish SBOM attestation

Usage:
  attest [flags]

Examples:
  trivy attest --type PREDICATE_TYPE --predicate PREDICATE_PATH BLOB_PATH
  # Publish SBOM attestation
  trivy attest --type cyclonedx --predicate ./sbom.cdx.json ./my-executable

Flags:
  -h, --help               help for attest
      --predicate string   specify the predicate file path
      --type string        specify the predicate type(cyclonedx)
```

## Related PRs
- https://github.com/aquasecurity/trivy/pull/3074
